### PR TITLE
fixed #8 Command workbench.files.action.closeFile is now deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "intellij-idea-keybindings",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "publisher": "k--kato",
     "engines": {
         "vscode": "1.3.x"
@@ -22,7 +22,7 @@
     "devDependencies": {
         "vscode": "^0.11.14",
         "gulp": "~3.9.1",
-        "gulp-cli": "~1.2.1",
+        "gulp-cli": "~1.2.2",
         "gulp-strip-json-comments": "~2.0.0",
         "gulp-rename": "~1.2.2",
         "gulp-jsbeautifier": "~2.0.3"
@@ -391,7 +391,7 @@
             {
                 "key": "ctrl+f4",
                 "mac": "cmd+w",
-                "command": "workbench.files.action.closeFile",
+                "command": "workbench.action.closeActiveEditor",
                 "intellij": "Close active editor tab"
             },
 

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1,6 +1,6 @@
 {
     "name": "intellij-idea-keybindings",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "publisher": "k--kato",
     "engines": {
         "vscode": "1.3.x"
@@ -23,7 +23,7 @@
     "devDependencies": {
         "vscode": "^0.11.14",
         "gulp": "~3.9.1",
-        "gulp-cli": "~1.2.1",
+        "gulp-cli": "~1.2.2",
         "gulp-strip-json-comments": "~2.0.0",
         "gulp-rename": "~1.2.2",
         "gulp-jsbeautifier": "~2.0.3"

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -408,7 +408,7 @@
             {
                 "key": "ctrl+f4",
                 "mac": "cmd+w",
-                "command": "workbench.files.action.closeFile",
+                "command": "workbench.action.closeActiveEditor",
                 "intellij": "Close active editor tab"
             },
 


### PR DESCRIPTION
- [x] Command workbench.files.action.closeFile is now deprecated

vscode/issues/6605