### PR TITLE
Add select / unselect next occurrence keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ ctrl+- | cmd+- | Collapse code block | Yes
 ctrl+shift+= | cmd+shift+= | Expand all | Yes
 ctrl+shift+- | cmd+shift+- | Collapse all | Yes
 ctrl+f4 | cmd+w | Close active editor tab | Yes
+alt+j | ctrl+g | Add selection for Next Occurrence | Yes
+alt+shift+j | ctrl+shift+g | Unselect Occurrence | Yes
 
 ### Search/Replace
 

--- a/package.json
+++ b/package.json
@@ -393,6 +393,18 @@
                 "mac": "cmd+w",
                 "command": "workbench.action.closeActiveEditor",
                 "intellij": "Close active editor tab"
+            }, {
+                "key": "alt+j",
+                "mac": "ctrl+g",
+                "command": "editor.action.addSelectionToNextFindMatch",
+                "when": "editorFocus",
+                "intellij": "Add selection for Next Occurrence"
+            }, {
+                "key": "alt+shift+j",
+                "mac": "ctrl+shift+g",
+                "command": "cursorUndo",
+                "when": "editorTextFocus",
+                "intellij": "Unselect Occurrence"
             },
 
 

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -411,6 +411,20 @@
                 "command": "workbench.action.closeActiveEditor",
                 "intellij": "Close active editor tab"
             },
+            {
+                "key": "alt+j",
+                "mac": "ctrl+g",
+                "command":"editor.action.addSelectionToNextFindMatch",
+                "when": "editorFocus",
+                "intellij": "Add selection for Next Occurrence"
+            },
+            {
+                "key": "alt+shift+j",
+                "mac": "ctrl+shift+g",
+                "command":"cursorUndo",
+                "when": "editorTextFocus",
+                "intellij": "Unselect Occurrence"
+            },
 
             /*---------------------------------------------------------------*\
              * Search/Replace


### PR DESCRIPTION
These keybindings are wonderfully helpful for multi-cursor editing. Make a selection, then hit `ctrl+g` on Mac to hop to the next occurrence. Very nice when traditional refactoring keybindings don't quite work for the circumstance.