### PR TITLE
Update package.json with a compatible engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.2.6",
     "publisher": "k--kato",
     "engines": {
-        "vscode": "1.7.x"
+        "vscode": "^1.7.0"
     },
     "displayName": "IntelliJ IDEA Keybindings",
     "description": "Port of IntelliJ IDEA Keybindings",


### PR DESCRIPTION
VSCode supports the `^1.7.0` syntax, not the `1.7.x` one.

This PR fixes that. I suggest to republish this extension to the store, so your users are able to install the latest version.

I will do Microsoft/vscode-vsce#143 so this doesn't happen in the future.