### PR TITLE
Updated mapping as per https://github.com/Microsoft/vscode/issues/28383

### DIFF
--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1365,7 +1365,7 @@
             {
                 "key": "alt+9",
                 "mac": "cmd+9",
-                "command": "workbench.view.git",
+                "command": "workbench.view.scm",
                 "when": "editorFocus",
                 "intellij": "Open corresponding tool window (Git)"
             },


### PR DESCRIPTION
alt+9 was displaying warning "command 'workbench.view.git' not found"
As per https://github.com/Microsoft/vscode/issues/28383 thread, 'workbench.view.git' changed to 'workbench.view.scm'.
Updated same.