### PR TITLE
fix cmd+k commit shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -1217,7 +1217,7 @@
             {
                 "key": "ctrl+k",
                 "mac": "cmd+k",
-                "command": "workbench.action.git.input-commit",
+                "command": "git.commitAll",
                 "when": "!inDebugMode && !terminalFocus",
                 "intellij": "Commit project to VCS"
             },

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1217,7 +1217,7 @@
             {
                 "key": "ctrl+k",
                 "mac": "cmd+k",
-                "command": "workbench.action.git.input-commit",
+                "command": "git.commitAll",
                 "when": "!inDebugMode && !terminalFocus",
                 "intellij": "Commit project to VCS"
             },


### PR DESCRIPTION
Keep getting errors that `workbench.action.git.input-commit` doesn't exist. Having played with it locally it seems it's now `git.commitAll` so fix `cmd+k` to use the new command