### PR TITLE
In mac, the "shift+cmd+[" && shift+cmd+]" will always switch the terminal

### DIFF
--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -2076,12 +2076,14 @@
                 "key": "",
                 "mac": "shift+cmd+[",
                 "command": "workbench.action.terminal.focusPrevious",
+                "when": "terminalFocus",
                 "intellij": "Select previous tab (Terminal)"
             },
             {
                 "key": "",
                 "mac": "shift+cmd+]",
                 "command": "workbench.action.terminal.focusNext",
+                "when": "terminalFocus",
                 "intellij": "Select next tab (Terminal)"
             },
             {


### PR DESCRIPTION
I found that the conditions have been deleted, I think it shoube be added.
I think it will fix #387 